### PR TITLE
protect against undef string comparison

### DIFF
--- a/lib/HTML/Restrict.pm
+++ b/lib/HTML/Restrict.pm
@@ -124,9 +124,17 @@ sub _build_parser {
                             && $attr->{href} )
                         {
                             my $uri = URI->new( $attr->{$source_type} );
-                            delete $attr->{$source_type}
-                                if none( @{ $self->get_uri_schemes } ) eq
-                                    $uri->scheme;
+                            if (defined $uri->scheme) {
+                                delete $attr->{$source_type}
+                                    if none(
+                                        grep defined, @{ $self->get_uri_schemes }
+                                    ) eq $uri->scheme;
+                            }
+                            else {  # relative uri
+                                delete $attr->{$source_type}
+                                    unless grep !defined,
+                                        @{ $self->get_uri_schemes };
+                            }
                         }
                     }
 

--- a/t/scheme.t
+++ b/t/scheme.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+
+use Test::More;
+use HTML::Restrict;
+
+my $hr = HTML::Restrict->new(
+    rules => {
+        a => [qw( href )],
+    },
+);
+
+$hr->set_uri_schemes([ 'http', 'https', undef, 'ftp' ]);
+
+cmp_ok(
+    $hr->process( '<a href="http://example.com">link</a>' ),
+        'eq', '<a href="http://example.com">link</a>',
+    'http scheme preserved',
+);
+
+cmp_ok(
+    $hr->process( '<a href="https://example.com">link</a>' ),
+        'eq', '<a href="https://example.com">link</a>',
+    'https scheme preserved',
+);
+
+cmp_ok(
+    $hr->process( '<a href="/some/file">link</a>' ),
+        'eq', '<a href="/some/file">link</a>',
+    'relative scheme preserved',
+);
+
+cmp_ok(
+    $hr->process( '<a href="ftp://example.com">link</a>' ),
+        'eq', '<a href="ftp://example.com">link</a>',
+    'ftp scheme preserved',
+);
+
+cmp_ok(
+    $hr->process( '<a href="file://example.com">link</a>' ),
+        'eq', '<a>link</a>',
+    'file scheme removed',
+);
+
+# disable relative schemes
+$hr->set_uri_schemes([ 'http', 'https', 'ftp' ]);
+
+cmp_ok(
+    $hr->process( '<a href="/some/file">link</a>' ),
+        'eq', '<a>link</a>',
+    'relative scheme removed',
+);
+
+done_testing();


### PR DESCRIPTION
Due to checking for relative URI schemes (represented by undef), I am getting uninitialized string comparison warnings in my app. Perl6::Junction does not have warnings enabled, and as a result, testing on the command line does not produce any warnings.

The problem is here:

``` perl
if none( @{ $self->get_uri_schemes } ) eq $uri->scheme;
```

where either side of the expression can cause an undef comparison.

My fix adds a few more lines, but I have also provided thorough tests. Please let me know what you think.
