### PR TITLE
Check URI scheme for src attributes

### DIFF
--- a/lib/HTML/Restrict.pm
+++ b/lib/HTML/Restrict.pm
@@ -120,8 +120,7 @@ sub _build_parser {
 
                     foreach my $source_type ( 'href', 'src' ) {
 
-                        if ( exists $attr->{$source_type}
-                            && $attr->{href} )
+                        if ( $attr->{$source_type} )
                         {
                             my $uri = URI->new( $attr->{$source_type} );
                             delete $attr->{$source_type}

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -110,4 +110,10 @@ cmp_ok( $hr->process( '000' ), 'eq', '000', "untrue values not processed");
 
 ok( !$hr->process("<html>"), "process only HTML" );
 
+
+# bugfix: check URI scheme for "src" attributes
+$hr = HTML::Restrict->new( rules => { img => [qw( src )] } );
+$hr->set_uri_schemes( [ undef, 'http', 'https' ] );
+cmp_ok( $hr->process('<img src="file:/some/file">'), 'eq', '<img>' );
+
 done_testing();


### PR DESCRIPTION
Me again... This time with a bugfix.

> As of version 1.0.3, URI scheme checking is performed on all href and src tag attributes.

 "src" attributes are not being checked:

``` perl
my $hr = HTML::Restrict->new(
    rules => {
        a      => [qw( href )],
        img    => [qw( src  )],
    },
);

$hr->set_uri_schemes( [ undef, 'http', 'https' ] );

say $hr->process('<a href="file:/some/file">click here</a>');
# <a>click here</a>

say $hr->process('<img src="file:/some/file">');
# <img src="file:/some/file">
```
