### PR TITLE
Allow attributes to be validated against regexes

### DIFF
--- a/t/attribute_constraints.t
+++ b/t/attribute_constraints.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+
+use Test::More;
+use HTML::Restrict;
+
+my $hr = HTML::Restrict->new(
+    rules => {
+        iframe => [
+            qw( width height ),
+            [ src         => qr{^http://www\.youtube\.com} ],
+            [ frameborder => qr{^(0|1)$} ],
+        ],
+    },
+);
+
+cmp_ok(
+    $hr->process('<iframe width="560" height="315" src="http://www.youtube.com/embed/9gKeRZM2Iyc" frameborder="0"></iframe>'),
+           'eq', '<iframe width="560" height="315" src="http://www.youtube.com/embed/9gKeRZM2Iyc" frameborder="0"></iframe>',
+    'all constraints pass',
+);
+
+cmp_ok(
+    $hr->process('<iframe width="560" height="315" src="http://www.hostile.com/" frameborder="0"></iframe>'),
+           'eq', '<iframe width="560" height="315" frameborder="0"></iframe>',
+    'one constraint fails',
+);
+
+cmp_ok(
+    $hr->process('<iframe width="560" height="315" src="http://www.hostile.com/" frameborder="A"></iframe>'),
+           'eq', '<iframe width="560" height="315"></iframe>',
+    'two constraints fail',
+);
+
+done_testing;


### PR DESCRIPTION
Yes, another one... I know this module supposed to be small and simple. But this is a very useful feature, and it does not add much complexity. Please reject if it is too much for you, I am happy to maintain my own fork.

I did not modify the documentation except for adding the following example to the synopsis:

``` perl
# you can also specify a regex to be tested against the attribute value
my $hr = HTML::Restrict->new(
    rules => {
        iframe => [
            qw( width height allowfullscreen ),
            [ src         => qr{^http://www\.youtube\.com} ],
            [ frameborder => qr{^(0|1)$} ],
        ],
        img    => [
            qw( alt ),
            [ src => qr{^/my/images/} ],
        ],
    },
);

my $html = '<img src="http://www.example.com/image.jpg" alt="Alt Text">';
my $processed = $hr->process( $html );
# $processed now equals: <img alt="Alt Text">
```
