### PR TITLE
Ensure stripper stack is always reset

### DIFF
--- a/lib/HTML/Restrict.pm
+++ b/lib/HTML/Restrict.pm
@@ -241,6 +241,9 @@ sub process {
     }
     $self->_processed( $text );
 
+    # ensure stripper stack is reset in case of broken html
+    $self->_stripper_stack([ ]);
+
     return $self->_processed;
 
 }

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -110,4 +110,12 @@ cmp_ok( $hr->process( '000' ), 'eq', '000', "untrue values not processed");
 
 ok( !$hr->process("<html>"), "process only HTML" );
 
+
+# bugfix: ensure stripper stack is reset in case of broken html
+$hr = HTML::Restrict->new;
+$hr->strip_enclosed_content( ['script'] );
+$hr->process('<script < b >');
+cmp_ok($hr->process('some text'), 'eq', 'some text', "stripper stack reset");
+
+
 done_testing();


### PR DESCRIPTION
I have found a bug in the strip_enclosed_content implementation. When deleting tags from the stripper stack in _delete_tag_from_stack(), it is assumed that the HTML within those tags is valid. However, if the HTML is broken, then the stack will not be cleared between calls to process(). Not only will this result in the $hr object becoming useless, but for every call to $hr->process the stripper stack will grow continuously, like this:

["script"]
["script", "script"]
["script", "script", "script"]
["script", "script", "script", "script"]
["script", "script", "script", "script", "script"]
["script", "script", "script", "script", "script", "script"]

As a test case, try this:

``` perl
use Data::Dump;
use HTML::Restrict;

my $hr = HTML::Restrict->new;

dd $hr->process('xxxxxxx');        # "xxxxxxx"
dd $hr->process('<script < b >');  # undef
dd $hr->process('xxxxxxx');        # undef
dd $hr->process('xxxxxxx');        # undef
dd $hr->process('xxxxxxx');        # undef
```
