### PR TITLE
Allow attributes to be validated against regexes using hashref(s)

### DIFF
--- a/README
+++ b/README
@@ -28,6 +28,27 @@ SYNOPSIS
 
         # $processed now equals: <b>hello</b> <img src="pic.jpg" alt="me" />
 
+        # you can also specify a regex to be tested against the attribute value
+        my $hr = HTML::Restrict->new(
+            rules => {
+                iframe => [
+                    qw( width height allowfullscreen ),
+                    {   src         => qr{^http://www\.youtube\.com},
+                        frameborder => qr{^(0|1)$},
+                    }
+                ],
+                img    => [
+                    qw( alt ),
+                    { src => qr{^/my/images/} },
+                ],
+            },
+        );
+
+        my $html = '<img src="http://www.example.com/image.jpg" alt="Alt Text">';
+        my $processed = $hr->process( $html );
+
+        # $processed now equals: <img alt="Alt Text">
+
 DESCRIPTION
     This module uses *HTML::Parser* to strip HTML from text in a restrictive
     manner. By default all HTML is restricted. You may alter the default

--- a/lib/HTML/Restrict.pm
+++ b/lib/HTML/Restrict.pm
@@ -98,10 +98,15 @@ sub _build_parser {
                 croak "All tag names must be lower cased";
             }
             if ( reftype $rules->{$tag_name} eq 'ARRAY' ) {
-                foreach my $attr_name ( @{ $rules->{$tag_name} } ) {
-                    if ( lc $attr_name ne $attr_name ) {
-                        croak "All attribute names must be lower cased";
-                    }
+                my @attr_names;
+                foreach my $attr_item ( @{ $rules->{$tag_name} } ) {
+                    ref $attr_item eq 'HASH'
+                        ? push(@attr_names, keys(%$attr_item))
+                        : push(@attr_names, $attr_item);
+                }
+                for (@attr_names) {
+                    croak "All attribute names must be lower cased"
+                        if lc $_ ne $_;
                 }
             }
         }
@@ -138,12 +143,23 @@ sub _build_parser {
                     }
 
                     foreach
-                        my $attribute ( @{ $self->get_rules->{$tagname} } )
+                        my $attr_item ( @{ $self->get_rules->{$tagname} } )
                     {
-                        if ( exists $attr->{$attribute}
-                            && $attribute ne q{/} )
-                        {
-                            $more .= qq[ $attribute="$attr->{$attribute}" ];
+                        if (ref $attr_item eq 'HASH') {
+                            # validate against regex contraints
+                            for my $attr_name (sort keys %$attr_item) {
+                                if ( exists $attr->{$attr_name} ) {
+                                    $more .= qq[ $attr_name="$attr->{$attr_name}" ]
+                                        if $attr->{$attr_name} =~ $attr_item->{$attr_name};
+                                }
+                            }
+                        }
+                        else {
+                            my $attr_name = $attr_item;
+                            if ( exists $attr->{$attr_name} ) {
+                                $more .= qq[ $attr_name="$attr->{$attr_name}" ]
+                                    unless $attr_name eq q{/};
+                            }
                         }
                     }
 
@@ -315,6 +331,27 @@ behaviour by supplying your own tag rules.
     my $processed = $hr->process( $html );
 
     # $processed now equals: <b>hello</b> <img src="pic.jpg" alt="me" />
+
+    # you can also specify a regex to be tested against the attribute value
+    my $hr = HTML::Restrict->new(
+        rules => {
+            iframe => [
+                qw( width height allowfullscreen ),
+                {   src         => qr{^http://www\.youtube\.com},
+                    frameborder => qr{^(0|1)$},
+                }
+            ],
+            img    => [
+                qw( alt ),
+                { src => qr{^/my/images/} },
+            ],
+        },
+    );
+
+    my $html = '<img src="http://www.example.com/image.jpg" alt="Alt Text">';
+    my $processed = $hr->process( $html );
+
+    # $processed now equals: <img alt="Alt Text">
 
 =head1 CONSTRUCTOR AND STARTUP
 

--- a/t/attribute_constraints.t
+++ b/t/attribute_constraints.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+
+use Test::More;
+use HTML::Restrict;
+
+my $hr = HTML::Restrict->new(
+    rules => {
+        iframe => [
+            qw( width height ),
+            {   src         => qr{^http://www\.youtube\.com},
+                frameborder => qr{^(0|1)$},
+            }
+        ],
+    },
+);
+
+cmp_ok(
+    $hr->process('<iframe width="560" height="315" frameborder="0" src="http://www.youtube.com/embed/9gKeRZM2Iyc"></iframe>'),
+           'eq', '<iframe width="560" height="315" frameborder="0" src="http://www.youtube.com/embed/9gKeRZM2Iyc"></iframe>',
+    'all constraints pass',
+);
+
+cmp_ok(
+    $hr->process('<iframe width="560" height="315" src="http://www.hostile.com/" frameborder="0"></iframe>'),
+           'eq', '<iframe width="560" height="315" frameborder="0"></iframe>',
+    'one constraint fails',
+);
+
+cmp_ok(
+    $hr->process('<iframe width="560" height="315" src="http://www.hostile.com/" frameborder="A"></iframe>'),
+           'eq', '<iframe width="560" height="315"></iframe>',
+    'two constraints fail',
+);
+
+$hr = HTML::Restrict->new(
+    rules => {
+        iframe => [
+            { src         => qr{^http://www\.youtube\.com} },
+            { frameborder => qr{^(0|1)$}                   },
+            { height      => qr{^315$}                     },
+            { width       => qr{^560$}                     },
+        ],
+    },
+);
+
+cmp_ok(
+    $hr->process('<iframe width="560" height="315" frameborder="0" src="http://www.youtube.com/embed/9gKeRZM2Iyc"></iframe>'),
+           'eq', '<iframe src="http://www.youtube.com/embed/9gKeRZM2Iyc" frameborder="0" height="315" width="560"></iframe>',
+    'possible to maintain order',
+);
+
+done_testing;


### PR DESCRIPTION
Here is the new patch using hashref(s) instead of arrayrefs. Please could you adjust the Pod as necessary.
