### PR TITLE
Use a weak reference to HTML::Parser, eliminating circular ref.

### DIFF
--- a/lib/HTML/Restrict.pm
+++ b/lib/HTML/Restrict.pm
@@ -32,9 +32,10 @@ has 'debug' => (
 );
 
 has 'parser' => (
-    is      => 'ro',
-    lazy    => 1,
-    builder => '_build_parser',
+    is       => 'ro',
+    lazy     => 1,
+    builder  => '_build_parser',
+    weak_ref => 1,
 );
 
 has 'rules' => (

--- a/t/memory-leak.t
+++ b/t/memory-leak.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Test::More;
+use HTML::Restrict;
+use Scalar::Util qw(weaken);
+
+# Ensure that we don't have any circular references between the HTML::Restrict
+# object and its parser.
+my $hr = HTML::Restrict->new;
+my $p  = $hr->parser;
+
+my $weak_hr = $hr;
+my $weak_p  = $p;
+weaken($weak_hr);
+weaken($weak_p);
+
+undef $hr;
+undef $p;
+
+ok !defined $weak_hr, 'HTML::Restrict freed; no circular reference.';
+ok !defined $weak_p,  'HTML::Parser freed; no circular reference.';
+
+done_testing();


### PR DESCRIPTION
When the HTML::Parser object is created in "_build_parser", it holds a
reference to "$self" (the HTML::Restrict object) in the closures used to
do the parsing.  That creates a circular reference between the HTML::Parser
object and the HTML::Restrict object, which then causes us to leak
memory every time we're used (as neither of the objects will ever get
freed).

So, weaken our handle to the HTML::Parser object, breaking the circular
reference.
