### PR TITLE
swap namespace::clean for ::autoclean

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -9,4 +9,4 @@ requires 'Sub::Quote';
 requires 'Test::Fatal';
 requires 'Test::More';
 requires 'URI';
-requires 'namespace::autoclean';
+requires 'namespace::clean';

--- a/lib/HTML/Restrict.pm
+++ b/lib/HTML/Restrict.pm
@@ -2,10 +2,6 @@ use strict;
 
 package HTML::Restrict;
 
-use namespace::autoclean;
-
-use Moo 1.002000;
-
 use Carp qw( croak );
 use Data::Dump qw( dump );
 use HTML::Parser;
@@ -14,6 +10,9 @@ use List::MoreUtils qw( any none );
 use Scalar::Util qw( reftype weaken );
 use Sub::Quote 'quote_sub';
 use URI;
+
+use Moo 1.002000;
+use namespace::clean;
 
 has 'allow_comments' => (
     is      => 'rw',


### PR DESCRIPTION
- namespace::autoclean depends on and loads Class::MOP. Moving the
  imports before 'use Moo' and adding namespace::clean will
  accomplish the same thing with a lighter dependency chain.
