### PR TITLE
fix attribute value encoding

### DIFF
--- a/lib/HTML/Restrict.pm
+++ b/lib/HTML/Restrict.pm
@@ -5,6 +5,7 @@ package HTML::Restrict;
 use Carp qw( croak );
 use Data::Dump qw( dump );
 use HTML::Parser;
+use HTML::Entities qw( encode_entities );
 use Types::Standard qw[ Bool HashRef ArrayRef CodeRef ];
 use List::MoreUtils qw( any none );
 use Scalar::Util qw( reftype weaken );
@@ -156,7 +157,8 @@ sub _build_parser {
                             # validate against regex contraints
                             for my $attr_name (sort keys %$attr_item) {
                                 if ( exists $attr->{$attr_name} ) {
-                                    $more .= qq[ $attr_name="$attr->{$attr_name}" ]
+                                    my $value = encode_entities($attr->{$attr_name});
+                                    $more .= qq[ $attr_name="$value" ]
                                         if $attr->{$attr_name} =~ $attr_item->{$attr_name};
                                 }
                             }
@@ -164,7 +166,8 @@ sub _build_parser {
                         else {
                             my $attr_name = $attr_item;
                             if ( exists $attr->{$attr_name} ) {
-                                $more .= qq[ $attr_name="$attr->{$attr_name}" ]
+                                my $value = encode_entities($attr->{$attr_name});
+                                $more .= qq[ $attr_name="$value" ]
                                     unless $attr_name eq q{/};
                             }
                         }

--- a/t/xss.t
+++ b/t/xss.t
@@ -8,7 +8,7 @@ use HTML::Restrict;
 
 my $hr = HTML::Restrict->new;
 $hr->debug( 0 );
-$hr->set_rules( { a => ['href'] } );
+$hr->set_rules( { a => ['href', 'class'] } );
 
 my $text = '<a href="javascript:alert(1)">oops!</a>';
 
@@ -26,5 +26,10 @@ foreach my $uri (
     my $img = qq[<a href="$uri">click</a>];
     is $hr->process( $img ), $img, "good uri scheme preserved";
 }
+
+is $hr->process(
+  '<a class="&quot;&gt;&lt;script&gt;alert(&quot;oops&quot;);&lt;/script&gt;&lt;a href=&quot;"></a>'),
+  '<a class="&quot;&gt;&lt;script&gt;alert(&quot;oops&quot;);&lt;/script&gt;&lt;a href=&quot;"></a>',
+  'attribute value filtered';
 
 done_testing();


### PR DESCRIPTION
Attribute values need to be encoded in the output, since they are
decoded by the parser.  Without this, attribute values can be
constructed to include pretty much anything in the output.
