### PR TITLE
add code filters for attribute values

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -25,6 +25,7 @@ on 'configure' => sub {
 };
 
 on 'develop' => sub {
+  requires 'Code::TidyAll::Plugin::SortLines::Naturally';
   requires "Pod::Coverage::TrustPod" => "0";
   requires "Test::CPAN::Changes" => "0.19";
   requires "Test::Code::TidyAll" => "0.50";

--- a/lib/HTML/Restrict.pm
+++ b/lib/HTML/Restrict.pm
@@ -154,15 +154,28 @@ sub _build_parser {
                         my $attr_item ( @{ $self->get_rules->{$tagname} } ) {
                         if ( ref $attr_item eq 'HASH' ) {
 
-                            # validate against regex contraints
-                            for my $attr_name ( sort keys %$attr_item ) {
-                                if ( exists $attr->{$attr_name} ) {
-                                    my $value = encode_entities(
-                                        $attr->{$attr_name} );
-                                    $more .= qq[ $attr_name="$value" ]
-                                        if $attr->{$attr_name}
-                                        =~ $attr_item->{$attr_name};
+                            # validate or munge with regex or coderef contraints
+                            #
+                            for my $attr_name (
+                                sort grep exists $attr->{$_},
+                                keys %$attr_item
+                                ) {
+                                my $rule  = $attr_item->{$attr_name};
+                                my $value = $attr->{$attr_name};
+                                if ( ref $rule eq 'CODE' ) {
+                                    $value = $rule->($value);
+                                    next
+                                        if !defined $value;
                                 }
+                                elsif ( $value =~ $rule ) {
+
+                                    # ok
+                                }
+                                else {
+                                    next;
+                                }
+                                $more .= qq[ $attr_name="]
+                                    . encode_entities($value) . q["];
                             }
                         }
                         else {
@@ -480,6 +493,27 @@ value. This feature should be considered experimental for the time being:
 
     # $processed now equals: <img alt="Alt Text">
 
+As of 2.3.0, the value to be tested against can also be a code reference.  The
+code reference will be passed the value of the attribute, and should return
+either a string to use for the attribute value, or undef to remove the attribute.
+
+    my $hr = HTML::Restrict->new(
+        rules => {
+            span => [
+                { style     => sub {
+                    my $value = shift;
+                    # all colors are orange
+                    $value =~ s/\bcolor\s*:\s*[^;]+/color: orange/g;
+                    return $value;
+                } }
+            ],
+        },
+    );
+
+    my $html = '<span style="color: #0000ff;">This is blue</span>';
+    my $processed = $hr->process( $html );
+
+    # $processed now equals: <span style="color: orange;">
 
 =item * C<< trim => [0|1] >>
 

--- a/t/attribute_constraints.t
+++ b/t/attribute_constraints.t
@@ -63,4 +63,13 @@ cmp_ok(
     'possible to maintain order',
 );
 
+cmp_ok(
+    $hr->process(
+        q[<iframe src="http://www.youtube.com/&quot; onclick=&quot;alert('hi')"></iframe>]
+    ),
+    'eq',
+    q[<iframe src="http://www.youtube.com/&quot; onclick=&quot;alert(&#39;hi&#39;)"></iframe>],
+    'entities are re-encoded when regex match passes',
+);
+
 done_testing;

--- a/t/attribute_constraints.t
+++ b/t/attribute_constraints.t
@@ -72,4 +72,41 @@ cmp_ok(
     'entities are re-encoded when regex match passes',
 );
 
+$hr = HTML::Restrict->new(
+    rules => {
+        span => [
+            {
+                style => sub {
+                    my $value = shift;
+                    my @values;
+                    while ( $value
+                        =~ /(?:\A|;)\s*([a-z-]+)\s*:\s*([^;\n]+?)\s*(?=;|$)/gc
+                        ) {
+                        my ( $prop, $prop_value ) = ( $1, $2 );
+                        if (   $prop =~ /\A(?:margin|padding)\z/
+                            && $prop_value =~ /\A\d+(?:em|px|)\z/ ) {
+                            push @values, "$prop: $prop_value";
+                        }
+                    }
+                    return
+                        unless @values;
+                    return join '; ', @values;
+                }
+            },
+            {
+                class => sub { return undef }
+            },
+        ],
+    },
+);
+
+cmp_ok(
+    $hr->process(
+        '<span class="fish" style="margin: 2px; padding: 7px;border: 2px;">content</span>',
+    ),
+    'eq',
+    '<span style="margin: 2px; padding: 7px">content</span>',
+    'filter attributes by coderef',
+);
+
 done_testing;


### PR DESCRIPTION
Similar to replace_img, but more granular.  This allows munging subrefs to be
used for attribute filters, similar to the regex filters.  However, the
subref filters can munge the attribute content.  An undef return value
means to remove the attribute.

I can write up docs if this interface is approved.