### PR TITLE
Support shared rules via plugin packages.

### DIFF
--- a/lib/HTML/Restrict.pm
+++ b/lib/HTML/Restrict.pm
@@ -13,6 +13,8 @@ use Scalar::Util qw( reftype weaken );
 use Sub::Quote 'quote_sub';
 use URI;
 
+use HTML::Restrict::Constraints;
+
 use Moo 1.002000;
 use namespace::clean;
 
@@ -42,7 +44,8 @@ has 'parser' => (
 
 has 'rules' => (
     is       => 'rw',
-    isa      => HashRef,
+    isa      => HTML::Restrict::Constraints::Rules,
+    coerce   => HTML::Restrict::Constraints::Rules->coercion,
     required => 0,
     default  => quote_sub(q{ {} }),
     trigger  => \&_build_parser,
@@ -480,6 +483,10 @@ value. This feature should be considered experimental for the time being:
 
     # $processed now equals: <img alt="Alt Text">
 
+You can also specify rules by rules plugin name providing full or short package name.
+In case of short one prefix HTML::Restrict::Rules will be used.
+
+Rules plugin name should provide method C<rules> returning hashref.
 
 =item * C<< trim => [0|1] >>
 

--- a/lib/HTML/Restrict/Constraints.pm
+++ b/lib/HTML/Restrict/Constraints.pm
@@ -1,0 +1,69 @@
+
+use strict;
+use 5.006;
+
+package HTML::Restrict::Constraints;
+
+use Type::Library qw[ -base -declare Plugin Rules ];
+use Type::Utils qw[ -all ];
+use Types::Standard qw[ -types ];
+
+use mro;
+
+use namespace::clean;
+
+my %load_cache;
+my %plugin_cache;
+
+sub looks_like_rules_plugin {
+    my ($plugin) = @_;
+
+    unless (exists $load_cache{$plugin}) {
+        $load_cache{$plugin} = undef;
+
+        return unless eval "require $plugin; 1";
+        return unless $plugin->can ('rules');
+
+        $load_cache{$plugin} = $plugin;
+    };
+
+    return $load_cache{$plugin}
+}
+
+sub rules_plugin_package {
+    my ($class, $plugin) = @_;
+
+    return unless defined $class;
+    return unless defined $plugin;
+
+    my $key = "$class/$plugin";
+
+    unless (exists $plugin_cache{$key}) {
+        for my $candidate ( @{ mro::get_linear_isa ($class) } ) {
+            last if $plugin_cache{$key} = looks_like_rules_plugin ("${candidate}::$plugin");
+        }
+
+        $plugin_cache{$key} = looks_like_rules_plugin ($plugin)
+            unless defined $plugin_cache{$key};
+    }
+
+    return $plugin_cache{$key};
+}
+
+
+declare Plugin,
+    as Str,
+    where { defined rules_plugin_package ('HTML::Restrict::Rules', $_) },
+    message { "$_ doesn't look like rules plugin name" },
+    ;
+
+declare Rules,
+    as HashRef,
+    ;
+
+coerce Rules,
+    from Plugin,
+    via { rules_plugin_package ('HTML::Restrict::Rules', $_)->rules },
+    ;
+
+1;

--- a/t/attribute_constraints.t
+++ b/t/attribute_constraints.t
@@ -4,44 +4,60 @@ use warnings;
 use Test::More;
 use HTML::Restrict;
 
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use HTML::Restrict::Rules::Test::Iframe;
+
+sub rules_example {
+    my ($name, $hr) = @_;
+
+    cmp_ok(
+        $hr->process(
+            '<iframe width="560" height="315" frameborder="0" src="http://www.youtube.com/embed/9gKeRZM2Iyc"></iframe>'
+        ),
+        'eq',
+        '<iframe width="560" height="315" frameborder="0" src="http://www.youtube.com/embed/9gKeRZM2Iyc"></iframe>',
+        "$name - all constraints pass",
+    );
+
+    cmp_ok(
+        $hr->process(
+            '<iframe width="560" height="315" src="http://www.hostile.com/" frameborder="0"></iframe>'
+        ),
+        'eq',
+        '<iframe width="560" height="315" frameborder="0"></iframe>',
+        "$name - one constraint fails",
+    );
+
+    cmp_ok(
+        $hr->process(
+            '<iframe width="560" height="315" src="http://www.hostile.com/" frameborder="A"></iframe>'
+        ),
+        'eq',
+        '<iframe width="560" height="315"></iframe>',
+        "$name - two constraints fail",
+    );
+}
+
 my $hr = HTML::Restrict->new(
-    rules => {
-        iframe => [
-            qw( width height ),
-            {
-                src         => qr{^http://www\.youtube\.com},
-                frameborder => qr{^(0|1)$},
-            }
-        ],
-    },
+    rules => HTML::Restrict::Rules::Test::Iframe->rules,
 );
 
-cmp_ok(
-    $hr->process(
-        '<iframe width="560" height="315" frameborder="0" src="http://www.youtube.com/embed/9gKeRZM2Iyc"></iframe>'
-    ),
-    'eq',
-    '<iframe width="560" height="315" frameborder="0" src="http://www.youtube.com/embed/9gKeRZM2Iyc"></iframe>',
-    'all constraints pass',
+rules_example "with data structure", $hr;
+
+$hr = HTML::Restrict->new(
+    rules => 'Test::Iframe',
 );
 
-cmp_ok(
-    $hr->process(
-        '<iframe width="560" height="315" src="http://www.hostile.com/" frameborder="0"></iframe>'
-    ),
-    'eq',
-    '<iframe width="560" height="315" frameborder="0"></iframe>',
-    'one constraint fails',
+rules_example "with abbreviated plugin name", $hr;
+
+$hr = HTML::Restrict->new(
+    rules => 'HTML::Restrict::Rules::Test::Iframe',
 );
 
-cmp_ok(
-    $hr->process(
-        '<iframe width="560" height="315" src="http://www.hostile.com/" frameborder="A"></iframe>'
-    ),
-    'eq',
-    '<iframe width="560" height="315"></iframe>',
-    'two constraints fail',
-);
+rules_example "with full plugin name", $hr;
+
 
 $hr = HTML::Restrict->new(
     rules => {

--- a/t/lib/HTML/Restrict/Rules/Test/Iframe.pm
+++ b/t/lib/HTML/Restrict/Rules/Test/Iframe.pm
@@ -1,0 +1,20 @@
+
+use strict;
+use 5.006;
+
+package HTML::Restrict::Rules::Test::Iframe;
+
+sub rules {
+    +{
+        iframe => [
+            qw( width height ),
+            {
+                src         => qr{^http://www\.youtube\.com},
+                frameborder => qr{^(0|1)$},
+            }
+        ],
+    }
+}
+
+1;
+


### PR DESCRIPTION
Plugin package can be either short package name under HTML::Restrict::Rules
namespace or full package name.

Plugin package should provide method 'rules' returning configuration hashref